### PR TITLE
add enum list functionality

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -216,7 +216,11 @@ function IndentEditor(target_textarea) {
                 prev_indentation = prev_indentation.replace(/[-*+>]/g, ' ');
               }
             } else {
-              prev_indentation = /^[-*+>\s]*/.exec(prev_line)[0];
+              var digits = /^\s*(\d+)\.\s+/.exec(prev_line);
+              if (digits) {
+                prev_line = prev_line.replace(/\d+/, parseInt(digits,10) + 1);
+              }
+              prev_indentation = /^\s*(\d+)\.\s+|[-*+>\s]*/.exec(prev_line)[0];
             }
             cm.replaceRange(prev_indentation, sels[i].anchor, sels[i].head, "+input");
           }

--- a/src/indent_text.js
+++ b/src/indent_text.js
@@ -78,7 +78,7 @@ CodeMirror.defineMode("indent_text", function(cmCfg, modeCfg) {
         }
         state.sawTextBeforeOnLine = false;
         state.headerLevel = 0;
-        var leadingSpace = matchIntoLeadingSpace(stream, state, /^[-*+>\s]+/);
+        var leadingSpace = matchIntoLeadingSpace(stream, state, /^(\s*\d+\.\s+|[-*+>\s]+)/);
         if (leadingSpace) {
           if (stream.eol() && /^\s*$/.test(leadingSpace)) {
             return "leadingspace line-blank-line";


### PR DESCRIPTION
A first crack at enumerated list behaviour: will maintain blank space only indentation in enumerated lists (of the form: /^\s*(\d+)\.\s+/)/, and auto-increment numbers in consecutive lines on entry. Does not attempt to fix or re-number if things are moved/changed/deleted etc. after entry --- just intended to simplify enumerated list enty a little.

cheers,
andrew
